### PR TITLE
fix: add missing bitnami common chart

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -35,3 +35,6 @@ dependencies:
     version: 16.13.2
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: redis.enabled
+  - name: common
+    version: 2.2.4
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami


### PR DESCRIPTION
This is needed because there are many references to bitnami common chart features, like here: https://github.com/mastodon/chart/blob/main/templates/_helpers.tpl#L99